### PR TITLE
feat(configs): exports networks properly typed with generics

### DIFF
--- a/configs/package.json
+++ b/configs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/osx-commons-configs",
   "author": "Aragon Association",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "AGPL-3.0-or-later",
   "typings": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/configs/src/index.ts
+++ b/configs/src/index.ts
@@ -9,9 +9,14 @@ import * as mumbai from './deployments/mumbai.json';
 import * as polygon from './deployments/polygon.json';
 import * as sepolia from './deployments/sepolia.json';
 import * as networks from './networks.json';
+import {NetworkConfigs} from './types';
+
+export * from './types';
+
+const networksTyped: NetworkConfigs = networks;
 
 export {
-  networks,
+  networksTyped as networks,
   arbitrum,
   arbitrumSepolia,
   baseGoerli,

--- a/configs/src/types.ts
+++ b/configs/src/types.ts
@@ -1,0 +1,16 @@
+export type NetworkConfig = {
+  url: string;
+  isTestnet: boolean;
+  chainId: number;
+  aliases: NetworkAliases;
+};
+
+export type NetworkAliases = {
+  ethers5?: string;
+  ethers6?: string;
+  alchemySubgraphs?: string;
+};
+
+export type NetworkConfigs<T = NetworkConfig> = {
+  [network: string]: T;
+};


### PR DESCRIPTION
## Description

Configs package exports networks with a proper type that can be extended by generics

Task ID: [OS-925](https://aragonassociation.atlassian.net/browse/OS-925)

<!--- Use the https://www.conventionalcommits.org to name this PR and its commits.-->
<!--- Consider using https://commitizen.github.io/cz-cli/ for this purpose.-->

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.


[OS-925]: https://aragonassociation.atlassian.net/browse/OS-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ