### PR TITLE
ci: fixes reusable publish workflow to install deps before trying to publish

### DIFF
--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -28,6 +28,8 @@ jobs:
           cache: 'yarn'
           node-version: 18.x
           registry-url: https://registry.npmjs.org
+      - name: Install deps
+        run: yarn install --frozen-lockfile
       - name: Publish NPM pkg (${{ inputs.package }} - ${{ inputs.version }})
         run: yarn publish --no-git-tag-version --new-version ${{ inputs.version }}
         working-directory: ./${{ inputs.package }}


### PR DESCRIPTION
## Description

ci: fixes reusable publish workflow to install deps before trying to publish

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
