### PR TITLE
fix: createWrappedERC20TokenCalls function

### DIFF
--- a/subgraph/CHANGELOG.md
+++ b/subgraph/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.0.4
+
+### Fixed
+
+- Fix `createWrappedERC20TokenCalls` params while calling `createERC20TokenCalls`.
+
 ## v0.0.3
 
 ### Changed

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/osx-commons-subgraph",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The Aragon OSx subgraph package containing common utilities",
   "module": "index.ts",
   "types": "index.ts",

--- a/subgraph/src/mocks/token.ts
+++ b/subgraph/src/mocks/token.ts
@@ -68,7 +68,7 @@ export function createWrappedERC20TokenCalls(
   symbol: string = 'MT',
   decimals: string = '18'
 ): void {
-  createERC20TokenCalls(tokenAddress, name, symbol, decimals, totalSupply);
+  createERC20TokenCalls(tokenAddress, totalSupply, name, symbol, decimals);
   createMockGetter(tokenAddress, 'underlying', 'underlying():(address)', [
     ethereum.Value.fromAddress(Address.fromString(underlyingTokenAddress)),
   ]);


### PR DESCRIPTION
## Description

Fix createWrappedERC20TokenCalls

Task ID: [OS-999](https://aragonassociation.atlassian.net/browse/OS-999)

<!--- Use the https://www.conventionalcommits.org to name this PR and its commits.-->
<!--- Consider using https://commitizen.github.io/cz-cli/ for this purpose.-->

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.


[OS-999]: https://aragonassociation.atlassian.net/browse/OS-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ