### PR TITLE
fix: update yarn lock

### DIFF
--- a/.github/workflows/configs-tests.yml
+++ b/.github/workflows/configs-tests.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 18
 
       - name: 'Install the dependencies'
-        run: 'yarn install'
+        run: 'yarn install --frozen-lockfile'
 
       - name: 'Build the configs'
         run: 'yarn build'

--- a/.github/workflows/contracts-tests.yml
+++ b/.github/workflows/contracts-tests.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: 18
 
       - name: 'Install the dependencies'
-        run: 'yarn install'
+        run: 'yarn install --frozen-lockfile'
 
       - name: 'Build the contracts'
         run: 'yarn build'

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 18
 
       - name: 'Install the dependencies'
-        run: 'yarn install'
+        run: 'yarn install --frozen-lockfile'
 
       - name: 'Build the sdk'
         run: 'yarn build'

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 18
 
       - name: 'Install the dependencies'
-        run: 'yarn install'
+        run: 'yarn install --frozen-lockfile'
 
       - name: 'Test the subgraph'
         run: 'yarn test >> $GITHUB_STEP_SUMMARY'

--- a/subgraph/yarn.lock
+++ b/subgraph/yarn.lock
@@ -3440,7 +3440,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==
 
-typescript@^5.2.2:
+typescript@5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==


### PR DESCRIPTION
## Description

Release action failed 

https://github.com/aragon/osx-commons/actions/runs/7743549678/job/21115276697

Error says

```
yarn install v1.22.21
[1/4] Resolving packages...
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```


Task ID: [OS-?](https://aragonassociation.atlassian.net/browse/OS-?)

<!--- Use the https://www.conventionalcommits.org to name this PR and its commits.-->
<!--- Consider using https://commitizen.github.io/cz-cli/ for this purpose.-->

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
