### PR TITLE
feat: add ens resolving functions

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `resolveEns` and `resolveEnsWithProvider` functions
+- Add `resolveEnsName` and `resolveEnsNameWithProvider` functions
 
 ## v0.0.1
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `resolveEnsName` and `resolveEnsNameWithProvider` functions
+- Add `resolveEnsName` functions
 
 ## v0.0.1
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `resolveEns` and `resolveEnsWithProvider` functions 
+- Add `resolveEns` and `resolveEnsWithProvider` functions
 
 ## v0.0.1
 

--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UPCOMING]
 
+### Added
+
+- Add `resolveEns` and `resolveEnsWithProvider` functions 
+
 ## v0.0.1
 
 ### Changed

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@aragon/osx-commons-sdk",
   "author": "Aragon Association",
-  "version": "0.0.1-alpha.6",
+  "version": "0.0.1-alpha.7",
   "license": "MIT",
   "main": "dist/index.js",
   "module": "dist/osx-commons-sdk.esm.js",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -52,6 +52,7 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
+    "@aragon/osx-commons-configs": "^0.2.0",
     "@aragon/osx-ethers": "^1.3.0-rc0.4",
     "@aragon/osx-ethers-v1.0.0": "npm:@aragon/osx-ethers@1.2.1",
     "@aragon/sdk-ipfs": "^1.1.0",

--- a/sdk/src/ens/index.ts
+++ b/sdk/src/ens/index.ts
@@ -1,0 +1,1 @@
+export * from './utils';

--- a/sdk/src/ens/utils.ts
+++ b/sdk/src/ens/utils.ts
@@ -1,0 +1,27 @@
+import {InvalidEnsError, UnsupportedNetworkError} from '../errors';
+import {isEnsName} from '../validation';
+import {getNetworkByAlias} from '@aragon/osx-commons-configs';
+import {Networkish} from '@ethersproject/networks';
+import {JsonRpcProvider} from '@ethersproject/providers';
+
+export function resolveEnsName(
+  ensName: string,
+  provider: JsonRpcProvider
+): Promise<string | null> {
+  if (!isEnsName(ensName)) {
+    throw new InvalidEnsError(ensName);
+  }
+  return provider.resolveName(ensName);
+}
+
+export function resolveEnsNameWithProvider(
+  ensName: string,
+  network: Networkish
+): Promise<string | null> {
+  const aragonNetwork = getNetworkByAlias(network.toString());
+  if (!aragonNetwork) {
+    throw new UnsupportedNetworkError(network.toString());
+  }
+  const provider = new JsonRpcProvider(aragonNetwork.url, network);
+  return resolveEnsName(ensName, provider);
+}

--- a/sdk/src/ens/utils.ts
+++ b/sdk/src/ens/utils.ts
@@ -2,28 +2,28 @@ import {InvalidEnsError, UnsupportedNetworkError} from '../errors';
 import {isEnsName} from '../validation';
 import {getNetworkByAlias} from '@aragon/osx-commons-configs';
 import {Networkish} from '@ethersproject/networks';
-import {JsonRpcProvider} from '@ethersproject/providers';
+import {JsonRpcProvider, Provider} from '@ethersproject/providers';
 
 /**
  * Resolves an ENS name to an address given a provider
  *
  * @export
  * @param {string} ensName
- * @param {JsonRpcProvider} provider
+ * @param {Provider | Networkish} providerOrNetwork
  * @return {(Promise<string | null>)}
  */
 export function resolveEnsName(
   ensName: string,
-  providerOrNetwork: JsonRpcProvider | Networkish
+  providerOrNetwork: Provider | Networkish
 ): Promise<string | null> {
   // check if the ensName is valid
   if (!isEnsName(ensName)) {
     throw new InvalidEnsError(ensName);
   }
-  let provider: JsonRpcProvider;
+  let provider: Provider;
   // check if the providerOrNetwork is a provider or a network
   // if it's a provider, use it
-  if (providerOrNetwork instanceof JsonRpcProvider) {
+  if (providerOrNetwork instanceof Provider) {
     provider = providerOrNetwork;
     // any other case, assume it's a network and create a provider
   } else {

--- a/sdk/src/ens/utils.ts
+++ b/sdk/src/ens/utils.ts
@@ -4,6 +4,14 @@ import {getNetworkByAlias} from '@aragon/osx-commons-configs';
 import {Networkish} from '@ethersproject/networks';
 import {JsonRpcProvider} from '@ethersproject/providers';
 
+/**
+ * Resolves an ENS name to an address given a provider
+ *
+ * @export
+ * @param {string} ensName
+ * @param {JsonRpcProvider} provider
+ * @return {(Promise<string | null>)}
+ */
 export function resolveEnsName(
   ensName: string,
   provider: JsonRpcProvider
@@ -14,6 +22,14 @@ export function resolveEnsName(
   return provider.resolveName(ensName);
 }
 
+/**
+ * Resolves an ENS name to an address given a network
+ *
+ * @export
+ * @param {string} ensName
+ * @param {Networkish} network
+ * @return {(Promise<string | null>)}
+ */
 export function resolveEnsNameWithProvider(
   ensName: string,
   network: Networkish

--- a/sdk/src/ens/utils.ts
+++ b/sdk/src/ens/utils.ts
@@ -14,30 +14,24 @@ import {JsonRpcProvider} from '@ethersproject/providers';
  */
 export function resolveEnsName(
   ensName: string,
-  provider: JsonRpcProvider
+  providerOrNetwork: JsonRpcProvider | Networkish
 ): Promise<string | null> {
+  // check if the ensName is valid
   if (!isEnsName(ensName)) {
     throw new InvalidEnsError(ensName);
   }
-  return provider.resolveName(ensName);
-}
-
-/**
- * Resolves an ENS name to an address given a network
- *
- * @export
- * @param {string} ensName
- * @param {Networkish} network
- * @return {(Promise<string | null>)}
- */
-export function resolveEnsNameWithProvider(
-  ensName: string,
-  network: Networkish
-): Promise<string | null> {
-  const aragonNetwork = getNetworkByAlias(network.toString());
-  if (!aragonNetwork) {
-    throw new UnsupportedNetworkError(network.toString());
+  let provider: JsonRpcProvider;
+  // check if the providerOrNetwork is a provider or a network
+  // if it's a provider, use it
+  if (providerOrNetwork instanceof JsonRpcProvider) {
+    provider = providerOrNetwork;
+  // any other case, assume it's a network and create a provider
+  } else {
+    const aragonNetwork = getNetworkByAlias(providerOrNetwork.toString());
+    if (!aragonNetwork) {
+      throw new UnsupportedNetworkError(providerOrNetwork.toString());
+    }
+    provider = new JsonRpcProvider(aragonNetwork.url, providerOrNetwork);
   }
-  const provider = new JsonRpcProvider(aragonNetwork.url, network);
-  return resolveEnsName(ensName, provider);
+  return provider.resolveName(ensName);
 }

--- a/sdk/src/ens/utils.ts
+++ b/sdk/src/ens/utils.ts
@@ -25,7 +25,7 @@ export function resolveEnsName(
   // if it's a provider, use it
   if (providerOrNetwork instanceof JsonRpcProvider) {
     provider = providerOrNetwork;
-  // any other case, assume it's a network and create a provider
+    // any other case, assume it's a network and create a provider
   } else {
     const aragonNetwork = getNetworkByAlias(providerOrNetwork.toString());
     if (!aragonNetwork) {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -23,3 +23,5 @@ export * from './math';
 export * from './permission';
 export * from './proposal';
 export * from './time';
+
+export * from './ens';

--- a/sdk/test/unit/ens.test.ts
+++ b/sdk/test/unit/ens.test.ts
@@ -26,8 +26,8 @@ describe('ens', () => {
         // mocked provider
         const provider = new JsonRpcProvider();
         if (input.error) {
-          expect(async () => {
-            await resolveEnsName(input.input, provider);
+          await expect(() => {
+            resolveEnsName(input.input, provider);
           }).toThrow(input.error);
           continue;
         }
@@ -55,8 +55,8 @@ describe('ens', () => {
       for (const input of inputs) {
         // mocked provider
         if (input.error) {
-          expect(async () => {
-            await resolveEnsNameWithProvider(input.input, input.network);
+          await expect(() => {
+            resolveEnsNameWithProvider(input.input, input.network);
           }).toThrow(input.error);
           continue;
         }

--- a/sdk/test/unit/ens.test.ts
+++ b/sdk/test/unit/ens.test.ts
@@ -1,0 +1,74 @@
+import {
+  InvalidEnsError,
+  resolveEnsName,
+  resolveEnsNameWithProvider,
+} from '../../src';
+import {ADDRESS_ONE, TEST_ENS_NAME, TEST_HTTP_URI} from '../constants';
+import {JsonRpcProvider} from '@ethersproject/providers';
+
+describe('ens', () => {
+  describe('resolveEnsName', () => {
+    it('should return the correct value', async () => {
+      const inputs = [
+        {
+          input: TEST_ENS_NAME,
+          network: 'mainnet',
+          output: ADDRESS_ONE,
+        },
+        {
+          input: TEST_HTTP_URI,
+          network: 'mainnet',
+          output: '',
+          error: new InvalidEnsError(TEST_HTTP_URI),
+        },
+      ];
+      for (const input of inputs) {
+        // mocked provider
+        const provider = new JsonRpcProvider();
+        if (input.error) {
+          expect(async () => {
+            await resolveEnsName(input.input, provider);
+          }).toThrow(input.error);
+          continue;
+        }
+        jest.spyOn(provider, 'resolveName').mockResolvedValue(input.output);
+        const resolvedAddress = await resolveEnsName(input.input, provider);
+        expect(resolvedAddress).toEqual(input.output);
+      }
+    });
+  });
+  describe('resolveEnsNameWithProvider', () => {
+    it('should return the correct value', async () => {
+      const inputs = [
+        {
+          input: TEST_ENS_NAME,
+          network: 'mainnet',
+          output: ADDRESS_ONE,
+        },
+        {
+          input: TEST_HTTP_URI,
+          network: 'mainnet',
+          output: '',
+          error: new InvalidEnsError(TEST_HTTP_URI),
+        },
+      ];
+      for (const input of inputs) {
+        // mocked provider
+        if (input.error) {
+          expect(async () => {
+            await resolveEnsNameWithProvider(input.input, input.network);
+          }).toThrow(input.error);
+          continue;
+        }
+        jest
+          .spyOn(JsonRpcProvider.prototype, 'resolveName')
+          .mockResolvedValue(input.output);
+        const resolvedAddress = await resolveEnsNameWithProvider(
+          input.input,
+          input.network
+        );
+        expect(resolvedAddress).toEqual(input.output);
+      }
+    });
+  });
+});

--- a/sdk/test/unit/ens.test.ts
+++ b/sdk/test/unit/ens.test.ts
@@ -26,9 +26,9 @@ describe('ens', () => {
         // mocked provider
         const provider = new JsonRpcProvider();
         if (input.error) {
-          await expect(resolveEnsName(input.input, provider)).rejects.toThrow(
-            input.error
-          );
+          await expect(
+            async () => await resolveEnsName(input.input, provider)
+          ).rejects.toThrow(input.error);
           continue;
         }
         jest.spyOn(provider, 'resolveName').mockResolvedValue(input.output);
@@ -56,7 +56,8 @@ describe('ens', () => {
         // mocked provider
         if (input.error) {
           await expect(
-            resolveEnsNameWithProvider(input.input, input.network)
+            async () =>
+              await resolveEnsNameWithProvider(input.input, input.network)
           ).rejects.toThrow(input.error);
           continue;
         }

--- a/sdk/test/unit/ens.test.ts
+++ b/sdk/test/unit/ens.test.ts
@@ -1,15 +1,11 @@
-import {
-  InvalidEnsError,
-  resolveEnsName,
-  resolveEnsNameWithProvider,
-} from '../../src';
+import {InvalidEnsError, resolveEnsName} from '../../src';
 import {ADDRESS_ONE, TEST_ENS_NAME, TEST_HTTP_URI} from '../constants';
 import {JsonRpcProvider} from '@ethersproject/providers';
 
 describe('ens', () => {
   describe('resolveEnsName', () => {
-    it('should return the correct value', async () => {
-      const inputs = [
+    it('should receive a JsonRpcProvider and return the correct value', async () => {
+      const tests = [
         {
           input: TEST_ENS_NAME,
           network: 'mainnet',
@@ -22,24 +18,22 @@ describe('ens', () => {
           error: new InvalidEnsError(TEST_HTTP_URI),
         },
       ];
-      for (const input of inputs) {
+      for (const test of tests) {
         // mocked provider
         const provider = new JsonRpcProvider();
-        if (input.error) {
+        if (test.error) {
           await expect(
-            async () => await resolveEnsName(input.input, provider)
-          ).rejects.toThrow(input.error);
+            async () => await resolveEnsName(test.input, provider)
+          ).rejects.toThrow(test.error);
           continue;
         }
-        jest.spyOn(provider, 'resolveName').mockResolvedValue(input.output);
-        const resolvedAddress = await resolveEnsName(input.input, provider);
-        expect(resolvedAddress).toEqual(input.output);
+        jest.spyOn(provider, 'resolveName').mockResolvedValue(test.output);
+        const resolvedAddress = await resolveEnsName(test.input, provider);
+        expect(resolvedAddress).toEqual(test.output);
       }
     });
-  });
-  describe('resolveEnsNameWithProvider', () => {
-    it('should return the correct value', async () => {
-      const inputs = [
+    it('should receive a Networkish and return the correct value', async () => {
+      const tests = [
         {
           input: TEST_ENS_NAME,
           network: 'mainnet',
@@ -52,23 +46,19 @@ describe('ens', () => {
           error: new InvalidEnsError(TEST_HTTP_URI),
         },
       ];
-      for (const input of inputs) {
+      for (const test of tests) {
         // mocked provider
-        if (input.error) {
+        if (test.error) {
           await expect(
-            async () =>
-              await resolveEnsNameWithProvider(input.input, input.network)
-          ).rejects.toThrow(input.error);
+            async () => await resolveEnsName(test.input, test.network)
+          ).rejects.toThrow(test.error);
           continue;
         }
         jest
           .spyOn(JsonRpcProvider.prototype, 'resolveName')
-          .mockResolvedValue(input.output);
-        const resolvedAddress = await resolveEnsNameWithProvider(
-          input.input,
-          input.network
-        );
-        expect(resolvedAddress).toEqual(input.output);
+          .mockResolvedValue(test.output);
+        const resolvedAddress = await resolveEnsName(test.input, test.network);
+        expect(resolvedAddress).toEqual(test.output);
       }
     });
   });

--- a/sdk/test/unit/ens.test.ts
+++ b/sdk/test/unit/ens.test.ts
@@ -26,9 +26,9 @@ describe('ens', () => {
         // mocked provider
         const provider = new JsonRpcProvider();
         if (input.error) {
-          await expect(() => {
-            resolveEnsName(input.input, provider);
-          }).toThrow(input.error);
+          await expect(resolveEnsName(input.input, provider)).rejects.toThrow(
+            input.error
+          );
           continue;
         }
         jest.spyOn(provider, 'resolveName').mockResolvedValue(input.output);
@@ -55,9 +55,9 @@ describe('ens', () => {
       for (const input of inputs) {
         // mocked provider
         if (input.error) {
-          await expect(() => {
-            resolveEnsNameWithProvider(input.input, input.network);
-          }).toThrow(input.error);
+          await expect(
+            resolveEnsNameWithProvider(input.input, input.network)
+          ).rejects.toThrow(input.error);
           continue;
         }
         jest

--- a/sdk/yarn.lock
+++ b/sdk/yarn.lock
@@ -15,6 +15,13 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aragon/osx-commons-configs@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@aragon/osx-commons-configs/-/osx-commons-configs-0.2.0.tgz#32f83596f4a2e9e48aef61cf560c1c5b4d32a049"
+  integrity sha512-wCFtgmuGCzs8L5mCxVCYQ6uEu69IrofS7q2w7E1Fjk7/nWuSmRUpgmif3ki9BQq1qpOvDu2P+u3UNLnIz8J82g==
+  dependencies:
+    tslib "^2.6.2"
+
 "@aragon/osx-ethers-v1.0.0@npm:@aragon/osx-ethers@1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@aragon/osx-ethers/-/osx-ethers-1.2.1.tgz#a442048137153ed5a3ca4eff3f3927b45a5134b5"
@@ -7060,7 +7067,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.4.1:
+tslib@^2.0.3, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
## Description

Description:

Introducing ENS name resolution functions for Ethereum integration:

Changes:

- `resolveEns(name: string ,provider: JsonRpcProvider: Promise<string | null>`

    Resolves ENS names to Ethereum addresses using the provided Ethereum provider.


- `resolveEnsWithProvider(name: string, network: Networkish): Promise<string | null>` 

    Simplifies previous function by using the default provider url from `osx-commons-configs` and requiring only the network parameter.

Task ID: [OS-1027](https://aragonassociation.atlassian.net/browse/OS-1027)

<!--- Use the https://www.conventionalcommits.org to name this PR and its commits.-->
<!--- Consider using https://commitizen.github.io/cz-cli/ for this purpose.-->

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.


[OS-1027]: https://aragonassociation.atlassian.net/browse/OS-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ