### PR TITLE
CI: remove push contraints for tests

### DIFF
--- a/.github/workflows/configs-tests.yml
+++ b/.github/workflows/configs-tests.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    paths:
-      - 'configs/**'
-      - '.github/workflows/configs-*.yml'
 
 jobs:
   formatting-linting:

--- a/.github/workflows/contracts-tests.yml
+++ b/.github/workflows/contracts-tests.yml
@@ -7,9 +7,6 @@ on:
       INFURA_API_KEY:
         required: true
   push:
-    paths:
-      - 'contracts/**'
-      - '.github/workflows/contracts-*.yml'
 
 jobs:
   formatting-linting:

--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -4,9 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    paths:
-      - 'sdk/**'
-      - '.github/workflows/sdk-*.yml'
 
 jobs:
   formatting-linting:

--- a/.github/workflows/subgraph-tests.yml
+++ b/.github/workflows/subgraph-tests.yml
@@ -4,11 +4,6 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    paths:
-      - 'contracts/**'
-      - 'subgraph/**'
-      - '.github/workflows/subgraph-*.yml'
-
 jobs:
   formatting-linting:
     uses: ./.github/workflows/formatting-linting.yml

--- a/sdk/test/unit/context.test.ts
+++ b/sdk/test/unit/context.test.ts
@@ -284,19 +284,12 @@ describe('Context instances', () => {
     for (const provider of context.web3Providers) {
       expect(provider).toBeInstanceOf(JsonRpcProvider);
       expect(provider.connection.url).toBe('https://goerli.base.org/');
-      provider
-        .getNetwork()
-        .then(nw => {
-          expect(nw.chainId).toEqual(84531);
-          expect(nw.name).toEqual('baseGoerli');
-          expect(nw.ensAddress).toEqual(
-            LIVE_CONTRACTS[SupportedVersion.LATEST].baseGoerli
-              .ensRegistryAddress
-          );
-        })
-        .catch(err => {
-          throw err;
-        });
+      const network = provider.network;
+      expect(network.chainId).toEqual(84531);
+      expect(network.name).toEqual('baseGoerli');
+      expect(network.ensAddress).toEqual(
+        LIVE_CONTRACTS[SupportedVersion.LATEST].baseGoerli.ensRegistryAddress
+      );
     }
   });
 });


### PR DESCRIPTION
## Description

When commit gets pushed to the repo before it only ran the tests related to that commit. We had some issues doing this because of dependencies between packages in the same repo. To avoid changing stuff in one package breaking stuff in the other packages we test everything on all commits 

Task ID: [OS-1086](https://aragonassociation.atlassian.net/browse/OS-1086)

<!--- Use the https://www.conventionalcommits.org to name this PR and its commits.-->
<!--- Consider using https://commitizen.github.io/cz-cli/ for this purpose.-->

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.


[OS-1086]: https://aragonassociation.atlassian.net/browse/OS-1086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ