### PR TITLE
chore: release `osx-commons-sdk` version `0.0.1-alpha.6`

### DIFF
--- a/sdk/CHANGELOG.md
+++ b/sdk/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added missing `ROOT_PERMISSION_ID` to the `PLUGIN_REPO_PERMISSIONS` constant.
 - Created `SingleTargetPermission` type.
 - Copied files from [aragon/sdk commit 76b4fc](https://github.com/aragon/sdk/tree/76b4fc815cfacce60b7c983ef0ce53110761f23a)
 
@@ -26,3 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Constants `GraphqlNetworks`, `SupportedNetworksToGraphqlNetworks`, `UNSUPPORTED_PROPOSAL_METADATA_LINK`, `EMPTY_PROPOSAL_METADATA_LINK`, `UNAVAILABLE_PROPOSAL_METADATA`, `GRAPHQL_NODES`, `IPFS_ENDPOINTS`, `IPFS_NODES`, `LIVE_CONTRACTS`, `ADDITIONAL_NETWORKS`, `Permissions`, `PermissionIds`, `IPFS_CID_REGEX`, `IPFS_URI_REGEX`, `OSX_PROPOSAL_ID_REGEX`, `HEX_STRING_REGEX`, `ENS_REGEX`, `SUBDOMAIN_REGEX`.
   - Schemas `BigintSchema`, `AddressOrEnsSchema`, `AddressOrEnsWithoutAnySchema`, `VersionTagSchema`, `ApplyInstallationSchema`, `AbiSchema`, `ApplyUninstallationSchema`, `Uint8ArraySchema`, `IpfsUriSchema`, `SubdomainSchema`, `PaginationSchema`, `PrepareUninstallationSchema`, `MultiTargetPermissionSchema`, `PrepareInstallationSchema`, `PluginInstallItemSchema`.
   - Types in `types.ts`.
+
+### Removed
+
+- Removed event names since they are available through `osx-ethers`.


### PR DESCRIPTION
## Description

The previous PR https://github.com/aragon/osx-commons/pull/62 that was supposed to publish the NPM package upon merge did not because of the failing SDK test. This one is there to finally publish this package.

Task ID: none

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.
