### PR TITLE
feat: update generateActionEntityId to include all of data on caller, dao, callId and actionIndex

### DIFF
--- a/subgraph/CHANGELOG.md
+++ b/subgraph/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.0.5
+
+### Changed
+
+`getActionEntityId` now is composed of the caller, daoAddress, callId and the actionIndex.
+
 ## v0.0.4
 
 ### Fixed

--- a/subgraph/package.json
+++ b/subgraph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/osx-commons-subgraph",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The Aragon OSx subgraph package containing common utilities",
   "module": "index.ts",
   "types": "index.ts",

--- a/subgraph/src/ids/actions.ts
+++ b/subgraph/src/ids/actions.ts
@@ -1,0 +1,29 @@
+import {Address } from '@graphprotocol/graph-ts';
+import { generateEntityIdFromAddress } from "./ids";
+
+/**
+ * @param caller the user/plugin that will invoke the execute function on the DAO
+ * @param daoAddress the DAO address
+ * @param callId the callID determined by the user or plugin
+ * @param index the index # of the action in the batch
+ *
+ * @returns a deterministic Action ID for an action on the DAO.
+ * This implementation only relies on data that can be fetched
+ * from the event logs of the `Executed` event, so can be used
+ * by client applications to query both the OSx core and the plugin
+ * subgraphs.
+ */
+export function generateActionEntityId(
+  caller: Address,
+  daoAddress: Address,
+  callId: string,
+  index: i32
+): string {
+  return [
+    generateEntityIdFromAddress(caller),
+    generateEntityIdFromAddress(daoAddress),
+    callId,
+    index.toString(),
+  ].join('_');
+}
+

--- a/subgraph/src/ids/actions.ts
+++ b/subgraph/src/ids/actions.ts
@@ -1,5 +1,5 @@
-import {Address } from '@graphprotocol/graph-ts';
-import { generateEntityIdFromAddress } from "./ids";
+import {generateEntityIdFromAddress} from './ids';
+import {Address} from '@graphprotocol/graph-ts';
 
 /**
  * @param caller the user/plugin that will invoke the execute function on the DAO
@@ -26,4 +26,3 @@ export function generateActionEntityId(
     index.toString(),
   ].join('_');
 }
-

--- a/subgraph/src/ids/index.ts
+++ b/subgraph/src/ids/index.ts
@@ -1,3 +1,4 @@
+export * from './actions';
 export * from './balance';
 export * from './callbacks';
 export * from './dao';

--- a/subgraph/src/ids/proposal.ts
+++ b/subgraph/src/ids/proposal.ts
@@ -7,20 +7,6 @@ import {
 import {Address, BigInt, Bytes} from '@graphprotocol/graph-ts';
 
 /**
- * Generates a unique action ID using the given parameters.
- *
- * @param proposalId - The id of the proposal that the action belongs to.
- * @param index - The index of the action within the proposal.
- * @returns A concatenated ID string for the Action entity.
- */
-export function generateActionEntityId(
-  proposalEntityId: string,
-  index: i32
-): string {
-  return [proposalEntityId, index.toString()].join('_');
-}
-
-/**
  * Generates a unique identifier for a transaction action proposal entity.
  * @param proposalEntityId - The ID of the proposal entity.
  * @param txHash - The hash of the transaction.

--- a/subgraph/tests/ids/actions.test.ts
+++ b/subgraph/tests/ids/actions.test.ts
@@ -1,0 +1,31 @@
+import {generateActionEntityId} from '../../src';
+import {ADDRESS_ONE, ADDRESS_TWO} from '../constants';
+import {Address} from '@graphprotocol/graph-ts';
+import {describe, test, assert} from 'matchstick-as';
+
+function checksum(s: string): string {
+  return Address.fromHexString(s).toHexString();
+}
+
+describe('Actions ID generation', () => {
+  test('We correctly generate the action ID', () => {
+    let caller = ADDRESS_ONE;
+    let daoAddress = ADDRESS_TWO;
+    let callId = 'c4ll me';
+    let index = 255;
+
+    let actionId = generateActionEntityId(
+      Address.fromString(caller),
+      Address.fromString(daoAddress),
+      callId,
+      index
+    );
+
+    assert.stringEquals(
+      actionId,
+      [checksum(caller), checksum(daoAddress), callId, index.toString()].join(
+        '_'
+      )
+    );
+  });
+});

--- a/subgraph/tests/ids/actions.test.ts
+++ b/subgraph/tests/ids/actions.test.ts
@@ -9,12 +9,12 @@ function checksum(s: string): string {
 
 describe('Actions ID generation', () => {
   test('We correctly generate the action ID', () => {
-    let caller = ADDRESS_ONE;
-    let daoAddress = ADDRESS_TWO;
-    let callId = 'c4ll me';
-    let index = 255;
+    const caller = ADDRESS_ONE;
+    const daoAddress = ADDRESS_TWO;
+    const callId = 'c4ll me';
+    const index = 255;
 
-    let actionId = generateActionEntityId(
+    const actionId = generateActionEntityId(
       Address.fromString(caller),
       Address.fromString(daoAddress),
       callId,

--- a/subgraph/tests/ids/proposal.test.ts
+++ b/subgraph/tests/ids/proposal.test.ts
@@ -1,22 +1,13 @@
 import {
-  generateActionEntityId,
   generateProposalEntityId,
   generateTransactionActionsProposalEntityId,
 } from '../../src/ids/proposal';
 import {bigIntToBytes32} from '../../src/utils/utils';
-import {ADDRESS_ONE, DUMMY_BYTES32_HEX, DUMMY_PROPOSAL_ID} from '../constants';
+import {ADDRESS_ONE, DUMMY_BYTES32_HEX} from '../constants';
 import {Address, BigInt, Bytes} from '@graphprotocol/graph-ts';
 import {assert, describe, test} from 'matchstick-as';
 
 describe('Transaction Actions Proposal ID generation', () => {
-  test('`generateActionEntityId` should return the id representation of an action', () => {
-    const proposalId = DUMMY_PROPOSAL_ID;
-    const index = 0;
-
-    const expectedId = `${proposalId}_${index}`;
-
-    assert.stringEquals(generateActionEntityId(proposalId, index), expectedId);
-  });
   test('`generateTransactionActionsProposalEntityId` should return the id representation of a transaction actions proposal', () => {
     const proposalEntityId = generateProposalEntityId(
       Address.fromString(ADDRESS_ONE),

--- a/subgraph/tests/utils/utils.test.ts
+++ b/subgraph/tests/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import {bigIntToBytes32} from '../../src/utils/utils';
-import {Address, BigInt} from '@graphprotocol/graph-ts';
+import {BigInt} from '@graphprotocol/graph-ts';
 import {assert, describe, test} from 'matchstick-as/assembly/index';
 
 const ZERO_BYTES32 =

--- a/subgraph/tests/utils/utils.test.ts
+++ b/subgraph/tests/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import {bigIntToBytes32} from '../../src/utils/utils';
-import {BigInt} from '@graphprotocol/graph-ts';
+import {Address, BigInt} from '@graphprotocol/graph-ts';
 import {assert, describe, test} from 'matchstick-as/assembly/index';
 
 const ZERO_BYTES32 =


### PR DESCRIPTION
## Description

`getActionEntityId` now is composed of the caller, daoAddress, callId and the actionIndex. Added tests imported from token-voting

Task ID: [OS-1178](https://aragonassociation.atlassian.net/browse/OS-1178)

## Checklist:

- [x] I have selected the correct base branch.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I ran all tests with success and extended them if necessary.
- [x] I have updated the `CHANGELOG.md` file in the root folder.


[OS-1165]: https://aragonassociation.atlassian.net/browse/OS-1165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OS-1178]: https://aragonassociation.atlassian.net/browse/OS-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ