### PR TITLE
Update workflow to only publish the corresponding PRs in the release notes 

### DIFF
--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: 'develop'
+          fetch-depth: 0 # fetch all history
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## Description

Currently in the release notes all the package-related PRs are being added, this PR tries to solve this issue. 

for more information  check [this notion page](https://www.notion.so/aragonorg/Release-notes-always-include-all-package-PRs-da73de54c685494fb569e1cca2e6f3e7)


Task ID: [OS-?](https://aragonassociation.atlassian.net/browse/OS-?)

<!--- Use the https://www.conventionalcommits.org to name this PR and its commits.-->
<!--- Consider using https://commitizen.github.io/cz-cli/ for this purpose.-->

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I created tasks to update dependent repositories (OSx, Plugins)
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
