### PR TITLE
create proposal id not enforced

### DIFF
--- a/contracts/src/mocks/plugin/extensions/proposal/ProposalMock.sol
+++ b/contracts/src/mocks/plugin/extensions/proposal/ProposalMock.sol
@@ -27,5 +27,5 @@ contract ProposalMock is Proposal {
         bytes memory metadata
     ) external view returns (uint256) {}
 
-    function createProposalParamsABI() external view returns (string memory) {}
+    function customProposalParamsABI() external view returns (string memory) {}
 }

--- a/contracts/src/mocks/plugin/extensions/proposal/ProposalUpgradeableMock.sol
+++ b/contracts/src/mocks/plugin/extensions/proposal/ProposalUpgradeableMock.sol
@@ -27,5 +27,5 @@ contract ProposalUpgradeableMock is ProposalUpgradeable {
         bytes memory metadata
     ) external view returns (uint256) {}
 
-    function createProposalParamsABI() external view returns (string memory) {}
+    function customProposalParamsABI() external view returns (string memory) {}
 }

--- a/contracts/src/plugin/extensions/proposal/IProposal.sol
+++ b/contracts/src/plugin/extensions/proposal/IProposal.sol
@@ -54,11 +54,11 @@ interface IProposal {
     /// @notice The human-readable abi format for extra params included in `data` of `createProposal`.
     /// @dev Used for UI to easily detect what extra params the contract expects.
     /// @return abi ABI of params in `data` of `createProposal`.
-    function createProposalParamsABI() external view returns (string memory abi);
+    function customProposalParamsABI() external view returns (string memory abi);
 
     /// @notice Returns the proposal count determining the next proposal ID.
-    /// @dev This function has been deprecated but due to backwards compatibility, it still stays in the interface
-    /// but returns maximum value of uint256 to let consumers know not to depend on it anymore.
+    /// @dev This function has been deprecated but due to backwards compatibility, it still exists
+    /// in the interface but reverts to avoid ambiguity.
     /// @return The proposal count.
     function proposalCount() external view returns (uint256);
 }

--- a/contracts/src/plugin/extensions/proposal/IProposal.sol
+++ b/contracts/src/plugin/extensions/proposal/IProposal.sol
@@ -51,15 +51,6 @@ interface IProposal {
     /// @return bool Returns if proposal can be executed or not.
     function canExecute(uint256 proposalId) external view returns (bool);
 
-    /// @notice Creates a proposal Id.
-    /// @param actions The actions that will be executed after the proposal passes.
-    /// @param metadata The custom metadata that is passed when creating a proposal.
-    /// @return proposalId The id of the proposal.
-    function createProposalId(
-        Action[] memory actions,
-        bytes memory metadata
-    ) external view returns (uint256);
-
     /// @notice The human-readable abi format for extra params included in `data` of `createProposal`.
     /// @dev Used for UI to easily detect what extra params the contract expects.
     /// @return abi ABI of params in `data` of `createProposal`.

--- a/contracts/src/plugin/extensions/proposal/Proposal.sol
+++ b/contracts/src/plugin/extensions/proposal/Proposal.sol
@@ -11,17 +11,19 @@ import {IProposal} from "./IProposal.sol";
 /// @notice An abstract contract containing the traits and internal functionality to create and execute proposals that can be inherited by non-upgradeable DAO plugins.
 /// @custom:security-contact sirt@aragon.org
 abstract contract Proposal is IProposal, ERC165 {
+    error FunctionDeprecated();
+
     /// @inheritdoc IProposal
-    function proposalCount() public pure override returns (uint256) {
-        return type(uint256).max;
+    function proposalCount() public view virtual override returns (uint256) {
+        revert FunctionDeprecated();
     }
 
     /// @notice Creates a proposal Id.
-    /// @dev Uses timestamp and chain id to ensure more probability of uniqueness.
+    /// @dev Uses block number and chain id to ensure more probability of uniqueness.
     /// @param salt The extra salt to help with uniqueness.
     /// @return The id of the proposal.
     function _createProposalId(bytes32 salt) internal view virtual returns (uint256) {
-        return uint256(keccak256(abi.encode(block.chainid, block.timestamp, address(this), salt)));
+        return uint256(keccak256(abi.encode(block.chainid, block.number, address(this), salt)));
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
@@ -30,13 +32,13 @@ abstract contract Proposal is IProposal, ERC165 {
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         // In addition to the current interfaceId, also support previous version of the interfaceId
         // that did not include the following functions:
-        // `createProposal, canExecute, createProposalParamsABI`.
+        // `createProposal, canExecute, customProposalParamsABI`.
         return
             _interfaceId ==
             type(IProposal).interfaceId ^
                 IProposal.createProposal.selector ^
                 IProposal.canExecute.selector ^
-                IProposal.createProposalParamsABI.selector ||
+                IProposal.customProposalParamsABI.selector ||
             _interfaceId == type(IProposal).interfaceId ||
             super.supportsInterface(_interfaceId);
     }

--- a/contracts/src/plugin/extensions/proposal/Proposal.sol
+++ b/contracts/src/plugin/extensions/proposal/Proposal.sol
@@ -16,19 +16,26 @@ abstract contract Proposal is IProposal, ERC165 {
         return type(uint256).max;
     }
 
+    /// @notice Creates a proposal Id.
+    /// @dev Uses timestamp and chain id to ensure more probability of uniqueness.
+    /// @param salt The extra salt to help with uniqueness.
+    /// @return The id of the proposal.
+    function _createProposalId(bytes32 salt) internal view virtual returns (uint256) {
+        return uint256(keccak256(abi.encode(block.chainid, block.timestamp, address(this), salt)));
+    }
+
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
     /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         // In addition to the current interfaceId, also support previous version of the interfaceId
         // that did not include the following functions:
-        // `createProposal, canExecute, createProposalId, createProposalParamsABI`.
+        // `createProposal, canExecute, createProposalParamsABI`.
         return
             _interfaceId ==
             type(IProposal).interfaceId ^
                 IProposal.createProposal.selector ^
                 IProposal.canExecute.selector ^
-                IProposal.createProposalId.selector ^
                 IProposal.createProposalParamsABI.selector ||
             _interfaceId == type(IProposal).interfaceId ||
             super.supportsInterface(_interfaceId);

--- a/contracts/src/plugin/extensions/proposal/ProposalUpgradeable.sol
+++ b/contracts/src/plugin/extensions/proposal/ProposalUpgradeable.sol
@@ -14,20 +14,22 @@ import {IProposal} from "./IProposal.sol";
 abstract contract ProposalUpgradeable is IProposal, ERC165Upgradeable {
     using CountersUpgradeable for CountersUpgradeable.Counter;
 
+    error FunctionDeprecated();
+
     /// @notice The incremental ID for proposals and executions.
     CountersUpgradeable.Counter private proposalCounter;
 
     /// @inheritdoc IProposal
-    function proposalCount() public pure override returns (uint256) {
-        return type(uint256).max;
+    function proposalCount() public view virtual override returns (uint256) {
+        revert FunctionDeprecated();
     }
 
     /// @notice Creates a proposal Id.
-    /// @dev Uses timestamp and chain id to ensure more probability of uniqueness.
+    /// @dev Uses block number and chain id to ensure more probability of uniqueness.
     /// @param salt The extra salt to help with uniqueness.
     /// @return The id of the proposal.
     function _createProposalId(bytes32 salt) internal view virtual returns (uint256) {
-        return uint256(keccak256(abi.encode(block.chainid, block.timestamp, address(this), salt)));
+        return uint256(keccak256(abi.encode(block.chainid, block.number, address(this), salt)));
     }
 
     /// @notice Checks if this or the parent contract supports an interface by its ID.
@@ -36,13 +38,13 @@ abstract contract ProposalUpgradeable is IProposal, ERC165Upgradeable {
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         // In addition to the current interfaceId, also support previous version of the interfaceId
         // that did not include the following functions:
-        // `createProposal, canExecute, createProposalParamsABI`.
+        // `createProposal, canExecute, customProposalParamsABI`.
         return
             _interfaceId ==
             type(IProposal).interfaceId ^
                 IProposal.createProposal.selector ^
                 IProposal.canExecute.selector ^
-                IProposal.createProposalParamsABI.selector ||
+                IProposal.customProposalParamsABI.selector ||
             _interfaceId == type(IProposal).interfaceId ||
             super.supportsInterface(_interfaceId);
     }

--- a/contracts/src/plugin/extensions/proposal/ProposalUpgradeable.sol
+++ b/contracts/src/plugin/extensions/proposal/ProposalUpgradeable.sol
@@ -22,19 +22,26 @@ abstract contract ProposalUpgradeable is IProposal, ERC165Upgradeable {
         return type(uint256).max;
     }
 
+    /// @notice Creates a proposal Id.
+    /// @dev Uses timestamp and chain id to ensure more probability of uniqueness.
+    /// @param salt The extra salt to help with uniqueness.
+    /// @return The id of the proposal.
+    function _createProposalId(bytes32 salt) internal view virtual returns (uint256) {
+        return uint256(keccak256(abi.encode(block.chainid, block.timestamp, address(this), salt)));
+    }
+
     /// @notice Checks if this or the parent contract supports an interface by its ID.
     /// @param _interfaceId The ID of the interface.
     /// @return Returns `true` if the interface is supported.
     function supportsInterface(bytes4 _interfaceId) public view virtual override returns (bool) {
         // In addition to the current interfaceId, also support previous version of the interfaceId
         // that did not include the following functions:
-        // `createProposal, canExecute, createProposalId, createProposalParamsABI`.
+        // `createProposal, canExecute, createProposalParamsABI`.
         return
             _interfaceId ==
             type(IProposal).interfaceId ^
                 IProposal.createProposal.selector ^
                 IProposal.canExecute.selector ^
-                IProposal.createProposalId.selector ^
                 IProposal.createProposalParamsABI.selector ||
             _interfaceId == type(IProposal).interfaceId ||
             super.supportsInterface(_interfaceId);

--- a/contracts/test/plugin/extensions/proposal.ts
+++ b/contracts/test/plugin/extensions/proposal.ts
@@ -27,9 +27,7 @@ function proposalBaseTests(fixture: () => Promise<FixtureResult>) {
   it('returns max value of integer for backwards-compatibility', async () => {
     const {proposalMock} = await loadFixture(fixture);
 
-    expect(await proposalMock.proposalCount()).to.equal(
-      ethers.constants.MaxUint256
-    );
+    await expect(proposalMock.proposalCount()).to.be.reverted;
   });
 
   describe('ERC-165', async () => {


### PR DESCRIPTION
## Description

1. We would still need to check on TokenVoting/Multisig if `proposal` exists or not and if so, revert. The reason is if 2 proposals are created within the same block and with same metadata for some reason.  So I think my comments above the functions(where I mention "uniqueness" might be misleading).
2. The only way `createProposalId` on the interface(and having it as public function) itself would make sense is if it were `pure`, because in such case, it would be deterministic. If it's not `pure` but `view`, `contractA` will never get any advantage of calling `createProposalId` on the `contractB` in advance, because if it's view, it would trick/give the `contractA` wrong id than it would generate when actually creating. 
3. While we're on this PR, I think it would be better to also come up with a better name for `createProposalParamsABI`. 
4. about `proposalCount` to revert instead, this worries me. If some external contract(`contractA`) already calls `proposalCount()` function on `Multisig` and we now revert(considering Multisig upgrades), then `contractA`'s call always fails and if `try/catch` is not used, `contractA` could become completely unusable anymore.  I also get the idea that reverting could be safer(only in case if `contractA` depends on the result of `proposalCount` in a critical way which is more improbable tbh). 


Please include a summary of the change and be sure you follow the contributions rules we do provide [here](./CONTRIBUTIONS.md)

Task ID: [OS-?](https://aragonassociation.atlassian.net/browse/OS-?)

<!--- Use the https://www.conventionalcommits.org to name this PR and its commits.-->
<!--- Consider using https://commitizen.github.io/cz-cli/ for this purpose.-->

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I created tasks to update dependent repositories (OSx, Plugins)
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
