### PR TITLE
Add missing IProposal interface function names in changelog

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Executor` contract, simple executor that loops through the actions and executes them.
 - `RuledCondition` abstract contract that allows to create conditional permissions using rules.
 - `currentTargetConfig` configuration to the `Plugin` it allows the plugins to execute through the Dao or the configured target.
-- Included in the `IProposal` interface the functions `createProposal` `hasSucceeded` and `customProposalParamsABI`.
+- Included in the `IProposal` interface the functions `createProposal`, `hasSucceeded`, `execute`, `canExecute`, and `customProposalParamsABI`.
 - `MetadataExtension` and `MetadataExtensionUpgradeable` abstract contracts that allows metadata setup at plugin level.
 
 ### Changed


### PR DESCRIPTION
## Description

Please include a summary of the change and be sure you follow the contributions rules we do provide [here](./CONTRIBUTIONS.md)

Task ID: [OS-?](https://aragonassociation.atlassian.net/browse/OS-?)

<!--- Use the https://www.conventionalcommits.org to name this PR and its commits.-->
<!--- Consider using https://commitizen.github.io/cz-cli/ for this purpose.-->

## Checklist:

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I created tasks to update dependent repositories (OSx, Plugins)
- [ ] I ran all tests with success and extended them if necessary.
- [ ] I have updated the `CHANGELOG.md` file in the root folder.
